### PR TITLE
Add missing MONGODB_URI + SERVER_SECRET env vars

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,6 +2,10 @@ name: ci
 
 on: push
 
+env:
+  SERVER_SECRET: ${{ secrets.SERVER_SECRET }}
+  MONGODB_URI: ${{ secrets.MONGODB_URI }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest 


### PR DESCRIPTION
These are temporary. Deploy otherwise fails at 'npm test'.
Probably we need access to a MongoDB instance for the backend to work.